### PR TITLE
Fixed IPFS extends

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "events";
 
 export as namespace ipfs;
 
@@ -5,7 +6,7 @@ export = IPFS;
 
 type Callback<T> = (error: Error, result?: T) => void;
 
-declare class IPFS {
+declare class IPFS extends EventEmitter {
     constructor(options: IPFS.Options);
 
     types: IPFS.Types;
@@ -21,12 +22,12 @@ declare class IPFS {
     version(options: any, callback: (error: Error, version: IPFS.Version) => void): void ;
     version(options: any): Promise<IPFS.Version>;
     version(callback: (error: Error, version: IPFS.Version) => void): void ;
-    version(): Promise<IPFS.Version>; 
+    version(): Promise<IPFS.Version>;
 
     id(options: any, callback: (error: Error, version: IPFS.Id) => void): void ;
     id(options: any): Promise<IPFS.Id>;
     id(callback: (error: Error, version: IPFS.Id) => void): void ;
-    id(): Promise<IPFS.Id>; 
+    id(): Promise<IPFS.Id>;
 
     repo: IPFS.RepoAPI;
     bootstrap: any;
@@ -42,10 +43,7 @@ declare class IPFS {
     ping(callback: (error: Error) => void): void;
     ping(): Promise<void>;
 
-    pubsub: any; 
-
-    on(event: string, callback: () => void): IPFS;
-    once(event: string, callback: () => void): IPFS;
+    pubsub: any;
 }
 
 declare namespace IPFS {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@types/ipfs",
+  "version": "0.23.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,5 +11,7 @@
   "author": "Zohaib Rauf",
   "maintainer": "Beeno Tung",
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {
+    "@types/events": "^1.2.0"
+  }
 }


### PR DESCRIPTION
I was coding using your type definition file, and it turned out that arguments can not be used when using event listeners.
IPFS is a class that inherits from EventEmitter, so we made some modifications.